### PR TITLE
Fix guests page module link

### DIFF
--- a/admin/guests.html
+++ b/admin/guests.html
@@ -18,7 +18,7 @@
     ></script>
 
     <script defer src="./js/navigation.js"></script>
-    <script defer src="./js/guests.js"></script>
+    <script type="module" src="./js/guests/guests.js"></script>
   </head>
   <body>
     <nav


### PR DESCRIPTION
## Summary
- load `guests.js` as an ES module from `js/guests/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840bc7a51ac832aac910f1609fee0bd