### PR TITLE
Fix status sorting in invites list

### DIFF
--- a/admin/js/invites.js
+++ b/admin/js/invites.js
@@ -161,7 +161,8 @@ function renderGuests() {
       if (sortKey === "created")
         return new Date(b.created) - new Date(a.created);
       if (sortKey === "type") return a.type.localeCompare(b.type);
-      if (sortKey === "status") return a.status.localeCompare(b.status);
+      if (sortKey === "status")
+        return a.guestStatus.localeCompare(b.guestStatus);
       return 0;
     });
   }


### PR DESCRIPTION
## Summary
- fix status field reference in simple sorting when guests are not grouped

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840bcd66be8832a9a91ae17b7972cd6